### PR TITLE
ドキュメントのリンク先が404になっていたので修正

### DIFF
--- a/src/components/pages/Top/components/Documents/Documents.tsx
+++ b/src/components/pages/Top/components/Documents/Documents.tsx
@@ -1,5 +1,5 @@
-import { ListItem } from "./components/ListItem";
-import styles from "./Documents.module.scss";
+import { ListItem } from './components/ListItem'
+import styles from './Documents.module.scss'
 
 export const Documents = () => {
   return (
@@ -20,14 +20,11 @@ export const Documents = () => {
         text="🗃️状態管理"
         link="https://github.com/fumi-sagawa/next-simple-template/blob/main/docs/state-management.md"
       />
-      <ListItem
-        text="🧪テスト"
-        link="https://github.com/fumi-sagawa/next-simple-template/blob/main/docs/test.md"
-      />
+      <ListItem text="🧪テスト" link="https://github.com/fumi-sagawa/next-simple-template/blob/main/docs/test.md" />
       <ListItem
         text="🐶ファイル生成(Scaffold)"
         link="https://github.com/fumi-sagawa/next-simple-template/blob/main/docs/scaffolding.md"
       />
     </ul>
-  );
-};
+  )
+}

--- a/src/components/pages/Top/components/Documents/Documents.tsx
+++ b/src/components/pages/Top/components/Documents/Documents.tsx
@@ -1,27 +1,33 @@
-import { ListItem } from './components/ListItem'
-import styles from './Documents.module.scss'
+import { ListItem } from "./components/ListItem";
+import styles from "./Documents.module.scss";
 
 export const Documents = () => {
   return (
     <ul className={styles.list}>
-      <ListItem text="🧑‍💻概要" link="https://github.com/fumi-sagawa/next-ts-template/blob/main/docs/overview.md" />
+      <ListItem
+        text="🧑‍💻概要"
+        link="https://github.com/fumi-sagawa/next-simple-template/blob/main/docs/overview.md"
+      />
       <ListItem
         text="🧩コンポーネント設計"
-        link="https://github.com/fumi-sagawa/next-ts-template/blob/main/docs/component-design.md"
+        link="https://github.com/fumi-sagawa/next-simple-template/blob/main/docs/component-design.md"
       />
       <ListItem
         text="📁ディレクトリ構成"
-        link="https://github.com/fumi-sagawa/next-ts-template/blob/main/docs/directory-structure.md"
+        link="https://github.com/fumi-sagawa/next-simple-template/blob/main/docs/directory-structure.md"
       />
       <ListItem
         text="🗃️状態管理"
-        link="https://github.com/fumi-sagawa/next-ts-template/blob/main/docs/state-management.md"
+        link="https://github.com/fumi-sagawa/next-simple-template/blob/main/docs/state-management.md"
       />
-      <ListItem text="🧪テスト" link="https://github.com/fumi-sagawa/next-ts-template/blob/main/docs/test.md" />
+      <ListItem
+        text="🧪テスト"
+        link="https://github.com/fumi-sagawa/next-simple-template/blob/main/docs/test.md"
+      />
       <ListItem
         text="🐶ファイル生成(Scaffold)"
-        link="https://github.com/fumi-sagawa/next-ts-template/blob/main/docs/scaffolding.md"
+        link="https://github.com/fumi-sagawa/next-simple-template/blob/main/docs/scaffolding.md"
       />
     </ul>
-  )
-}
+  );
+};


### PR DESCRIPTION
index ページのドキュメントのリンクが、[https://github.com/fumi-sagawa/next-ts-template](https://github.com/fumi-sagawa/next-ts-template)でリンク先が404になっていたので、このGitHubリポジトリの[https://github.com/fumi-sagawa/next-simple-template](https://github.com/fumi-sagawa/next-simple-template)になるように修正しました。